### PR TITLE
Observe ngSrc & preloadBgImage for dynamic image changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 #angular-preload-image
 
-A simple AngularJS module to make it easy to pre-load images dynamic images with fallback support
+A simple AngularJS module to make it easy to pre-load images to prevent the horrible waterfall effect: [Demo](http://revillweb.github.io/angular-preload-image/).
 
 #Installation
 
 ##Install with bower
 
 ```
-bower install angular-dynamic-preload-image
+bower install angular-preload-image
 ```
 
 ##Include script files
@@ -20,7 +20,7 @@ bower install angular-dynamic-preload-image
 ##Add module dependency
 
 ```javascript
-angular.module('app', ['angular-dynamic-preload-image']);
+angular.module('app', ['angular-preload-image']);
 ```
 
 #Usage
@@ -45,8 +45,12 @@ MIT
 
 Check out the [demo](http://revillweb.github.io/angular-preload-image/) for an example of pre-loading background images and pre-loading standard images with AngularJS.
 
+#TO DO
+
+* Ability to know when all pre-loaded images have finished loading within the page
+* Extensive cross browser and device testing + fixes
  
 #Credit
 
-This project forked from [RevillWeb/angular-preload-image](https://github.com/RevillWeb/angular-preload-image).
+Inspiration taken from Ben Nadel's [post](http://www.bennadel.com/blog/2597-preloading-images-in-angularjs-with-promises.htm) about pre-loading images.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 #angular-preload-image
 
-A simple AngularJS module to make it easy to pre-load images to prevent the horrible waterfall effect: [Demo](http://revillweb.github.io/angular-preload-image/).
+A simple AngularJS module to make it easy to pre-load images dynamic images with fallback support
 
 #Installation
 
 ##Install with bower
 
 ```
-bower install angular-preload-image
+bower install angular-dynamic-preload-image
 ```
 
 ##Include script files
@@ -20,7 +20,7 @@ bower install angular-preload-image
 ##Add module dependency
 
 ```javascript
-angular.module('app', ['angular-preload-image']);
+angular.module('app', ['angular-dynamic-preload-image']);
 ```
 
 #Usage
@@ -45,12 +45,8 @@ MIT
 
 Check out the [demo](http://revillweb.github.io/angular-preload-image/) for an example of pre-loading background images and pre-loading standard images with AngularJS.
 
-#TO DO
-
-* Ability to know when all pre-loaded images have finished loading within the page
-* Extensive cross browser and device testing + fixes
  
 #Credit
 
-Inspiration taken from Ben Nadel's [post](http://www.bennadel.com/blog/2597-preloading-images-in-angularjs-with-promises.htm) about pre-loading images.
+This project forked from [RevillWeb/angular-preload-image](https://github.com/RevillWeb/angular-preload-image).
 

--- a/angular-preload-image.js
+++ b/angular-preload-image.js
@@ -1,53 +1,59 @@
 angular.module('angular-preload-image', []);
-angular.module('angular-preload-image').factory('preLoader', function(){
+angular.module('angular-preload-image').factory('preLoader', function () {
     return function (url, successCallback, errorCallback) {
         //Thank you Adriaan for this little snippet: http://www.bennadel.com/members/11887-adriaan.htm
-        angular.element(new Image()).bind('load', function(){
+        angular.element(new Image()).bind('load', function () {
             successCallback();
-        }).bind('error', function(){
+        }).bind('error', function () {
             errorCallback();
         }).attr('src', url);
     }
 });
-angular.module('angular-preload-image').directive('preloadImage', ['preLoader', function(preLoader){
+angular.module('angular-preload-image').directive('preloadImage', ['preLoader', function (preLoader) {
     return {
         restrict: 'A',
         terminal: true,
         priority: 100,
-        link: function(scope, element, attrs) {
-            var url = attrs.ngSrc;
+        link: function (scope, element, attrs) {
             scope.default = attrs.defaultImage || "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEWEygNWiLqlwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAMSURBVAjXY/j//z8ABf4C/tzMWecAAAAASUVORK5CYII=";
-            attrs.$set('src', scope.default);
-            preLoader(url, function(){
-                attrs.$set('src', url);
-            }, function(){
-                if (attrs.fallbackImage != undefined) {
-                    attrs.$set('src', attrs.fallbackImage);
-                }
-            });
+            attrs.$observe('ngSrc', function () {
+                var url = attrs.ngSrc;
+                attrs.$set('src', scope.default);
+                preLoader(url, function () {
+                    attrs.$set('src', url);
+                }, function () {
+                    if (attrs.fallbackImage != undefined) {
+                        attrs.$set('src', attrs.fallbackImage);
+                    }
+                });
+            })
+
         }
     };
 }]);
-angular.module('angular-preload-image').directive('preloadBgImage', ['preLoader', function(preLoader){
+angular.module('angular-preload-image').directive('preloadBgImage', ['preLoader', function (preLoader) {
     return {
         restrict: 'A',
-        link: function(scope, element, attrs) {
+        link: function (scope, element, attrs) {
             if (attrs.preloadBgImage != undefined) {
                 //Define default image
                 scope.default = attrs.defaultImage || "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEWEygNWiLqlwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAMSURBVAjXY/j//z8ABf4C/tzMWecAAAAASUVORK5CYII=";
-                element.css({
-                    'background-image': 'url("' + scope.default + '")'
-                });
-                preLoader(attrs.preloadBgImage, function(){
+
+                attrs.$observe('preloadBgImage', function () {
                     element.css({
-                        'background-image': 'url("' + attrs.preloadBgImage + '")'
+                        'background-image': 'url("' + scope.default + '")'
                     });
-                }, function(){
-                    if (attrs.fallbackImage != undefined) {
+                    preLoader(attrs.preloadBgImage, function () {
                         element.css({
-                            'background-image': 'url("' + attrs.fallbackImage + '")'
+                            'background-image': 'url("' + attrs.preloadBgImage + '")'
                         });
-                    }
+                    }, function () {
+                        if (attrs.fallbackImage != undefined) {
+                            element.css({
+                                'background-image': 'url("' + attrs.fallbackImage + '")'
+                            });
+                        }
+                    });
                 });
             }
         }


### PR DESCRIPTION
This change let you to observe ngSrc & preloadBgImage for dynamic attr interpolation.

ex:

``` javascript
<img preload-image ng-src="{{vm.imgUrl}}.png"
default-image="assets/images/placeholder.png" fallback-image="[URL]" />
```
